### PR TITLE
Implement textwrap.shorten

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- '3.3'
 - '3.4'
 - '3.5'
 - '3.6'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-testfixtures>=5.1.1,<6.0
-invoke>=0.20.4,<1.0
-pylint>=1.7.2,<2.0
+testfixtures>=5.2,<6.0
+invoke>=0.21,<1.0
+pylint>=1.7.4,<2.0
 yamllint>=1.8.1,<2.0
 coverage>=4.4.1,<5.0

--- a/test.py
+++ b/test.py
@@ -800,10 +800,11 @@ class TestWB(unittest.TestCase):
                   'This tweet is over 140 characters.'
         hashtag = '#testing'
         status = weatherBot.do_tweet(content, self.location, tweet_location, variable_location, hashtag=hashtag)
-        expected_text = 'This tweet is over 140 characters.\n' \
-                        'This tweet is over 140 characters.\n' \
-                        'This tweet is over 140 characters.\n' \
-                        'This tweet is over 140 ch\u2026 #testing'
+        expected_text = 'This tweet is over 140 characters. ' \
+                        'This tweet is over 140 characters. ' \
+                        'This tweet is over 140 characters. ' \
+                        'This tweet is over 140… #testing'
+
         self.assertEqual(status.text, expected_text)
 
     @replace('weatherBot.get_tweepy_api', mocked_get_tweepy_api)

--- a/weatherBot.py
+++ b/weatherBot.py
@@ -15,6 +15,7 @@ import os
 import pickle
 import random
 import sys
+import textwrap
 import time
 import traceback
 from datetime import datetime
@@ -228,7 +229,7 @@ def do_tweet(text, weather_location, tweet_location, variable_location, hashtag=
     logging.debug('Trying to tweet: %s', body)
     if len(body) > max_length:
         # horizontal ellipsis
-        body = body[:(max_length - 1)] + '\u2026'
+        body = textwrap.shorten(body, width=max_length, placeholder='\u2026')
         logging.warning('Status text is too long, tweeting the following instead: %s', body)
 
     if hashtag:


### PR DESCRIPTION
closes #26

This PR implements textwrap.shorten. However, there are a few caveats that I wanted to make sure you were aware of. 

Most importantly, this changes the output. See the docs [here](ttps://docs.python.org/3.4/library/textwrap.html#textwrap.shorten). The part to note is that whitespace is immediately dropped and replaced with single spaces. This means that characters like line breaks are not preserved. 

If this is intended behavior, great! If not, this PR might not want to be merged. Nevertheless, I feel it meets the requirements of the issue.